### PR TITLE
Detection of .xls files

### DIFF
--- a/src/SoftCreatR/MimeDetector/MimeDetector.php
+++ b/src/SoftCreatR/MimeDetector/MimeDetector.php
@@ -833,7 +833,9 @@ class MimeDetector
             }
 
             /**
-             * Microsoft Office Excel, according to this document @link https://www.garykessler.net/library/file_sigs.html
+             * Microsoft Office Excel, according to this document
+             * 
+             * @link https://www.garykessler.net/library/file_sigs.html
              */
             if (
                 $this->checkForBytes([0x09, 0x08, 0x10, 0x00, 0x00, 0x06, 0x05, 0x00], 2048)

--- a/src/SoftCreatR/MimeDetector/MimeDetector.php
+++ b/src/SoftCreatR/MimeDetector/MimeDetector.php
@@ -832,6 +832,19 @@ class MimeDetector
                 ];
             }
 
+            /**
+             * Microsoft Office Excel, according to this document @link https://www.garykessler.net/library/file_sigs.html
+             */
+            if (
+                $this->checkForBytes([0x09, 0x08, 0x10, 0x00, 0x00, 0x06, 0x05, 0x00], 2048)
+                || $this->checkForBytes([0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff], 512)
+            ) {
+                return [
+                    'ext' => 'xls',
+                    'mime' => 'application/vnd.ms-excel'
+                ];
+            }
+
             return [
                 'ext' => 'msi',
                 'mime' => 'application/x-msi'

--- a/src/SoftCreatR/MimeDetector/MimeDetector.php
+++ b/src/SoftCreatR/MimeDetector/MimeDetector.php
@@ -834,7 +834,7 @@ class MimeDetector
 
             /**
              * Microsoft Office Excel, according to this document
-             * 
+             *
              * @link https://www.garykessler.net/library/file_sigs.html
              */
             if (


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

# 🔀 Pull Request

## What does this PR do?

Support for detection of .xls (MS Office Excel) files that have the same header as .msi files - which can be used to send executable files disguised as .xls'es.
Comparing number of .xls files I found similiarity at 512 byte, that differ from .msi files.

## Test Plan

Test on plenty more .xls and .msi file.

